### PR TITLE
WIP: Replace NodeArray with Stdmap

### DIFF
--- a/src/Dictionary.h
+++ b/src/Dictionary.h
@@ -80,203 +80,11 @@
     2020-09-16 - use of namespace for NodeArray
  */
 
-
 #ifndef _DICTIONARY_H_
 #define _DICTIONARY_H_
 
-#ifndef _DICT_KEYLEN
-#define _DICT_KEYLEN 64
-#endif
-
-#if _DICT_KEYLEN < UINT8_MAX
-#define _DICT_KEY_TYPE  uint8_t
-#endif
-
-#if _DICT_KEYLEN >= UINT8_MAX && _DICT_KEYLEN < UINT16_MAX
-#define _DICT_KEY_TYPE  uint16_t
-#endif
-
-#if _DICT_KEYLEN >= UINT16_MAX && _DICT_KEYLEN < UINT32_MAX
-#define _DICT_KEY_TYPE  uint32_t
-#endif
-
-// What is the likelihood of a microcontroller having that much memory?
-#if _DICT_KEYLEN >= UINT32_MAX
-#define _DICT_KEY_TYPE  uint64_t
-#endif
-
-
-
-#ifndef _DICT_VALLEN
-#define _DICT_VALLEN 254
-#endif
-
-#if _DICT_VALLEN < UINT8_MAX
-#define _DICT_VAL_TYPE  uint8_t
-#endif
-
-#if _DICT_VALLEN >= UINT8_MAX && _DICT_VALLEN < UINT16_MAX
-#define _DICT_VAL_TYPE  uint16_t
-#endif
-
-#if _DICT_VALLEN >= UINT16_MAX && _DICT_VALLEN < UINT32_MAX
-#define _DICT_VAL_TYPE  uint32_t
-#endif
-
-#if _DICT_VALLEN >= UINT32_MAX
-#define _DICT_VAL_TYPE  uint64_t
-#endif
-
-
-
-#define DICTIONARY_OK         0
-#define DICTIONARY_ERR      (-1)
-#define DICTIONARY_MEM      (-2)
-#define DICTIONARY_OOB      (-3)
-
-#define DICTIONARY_COMMA    (-20)
-#define DICTIONARY_COLON    (-21)
-#define DICTIONARY_QUOTE    (-22)
-#define DICTIONARY_BCKSL    (-23)
-#define DICTIONARY_EOF      (-99)
-
-
-// There is no CRC calculation anymore, but the naming stuck
-#ifndef _DICT_CRC
-#define _DICT_CRC  32
-#endif
-
-#if !( _DICT_CRC == 16 || _DICT_CRC == 32 || _DICT_CRC == 64)
-#define _DICT_CRC  32
-#endif
-
-#if _DICT_CRC == 16
-#define uintNN_t uint16_t
-#endif
-
-#if _DICT_CRC == 32
-#define uintNN_t uint32_t
-#endif
-
-#if _DICT_CRC == 64
-#define uintNN_t uint64_t
-#endif
-
-#if defined(_DICT_COMPRESS_SHOCO)
-
-#define _DICT_COMPRESS
-#define _DICT_EXTRA 0
-#include "shoco/shoco.h"
-
-#elif defined (_DICT_COMPRESS_SMAZ)
-
-#define _DICT_COMPRESS
-#define _DICT_EXTRA 0
-extern "C" {
-#include "smaz/smaz.h"
-}
-#endif
-
-#ifndef _DICT_EXTRA
-#define _DICT_EXTRA 1
-#endif
-
-
-#include <Arduino.h>
+#include "DictionaryDeclarations.h"
 #include "NodeArray.h"
-using namespace NodeArray;
-
-#ifdef _DICT_PACK_STRUCTURES
-class __attribute((__packed__)) Dictionary {
-#else
-class Dictionary {
-#endif
-  public:
-    Dictionary(size_t init_size = 10);
-    ~Dictionary();
-
-    inline int8_t       insert(const String& keystr, const String& valstr);
-    int8_t              insert(const char* keystr, const char* valstr);
-    
-    inline String       search(const String& keystr);
-    String              search(const char* keystr);
-    String              key(size_t i);
-    String              value(size_t i);
-
-    void                destroy();
-    inline int8_t       remove(const String& keystr);
-    int8_t              remove(const char* keystr);
-
-    size_t              size();
-    size_t              jsize();
-    size_t              esize();
-    
-    String              json();
-    inline int8_t       jload (const String& json, int num = 0);
-    int8_t              jload (const char* json, int num = 0);
-    int8_t              merge (Dictionary& dict);
-
-
-    void operator = (Dictionary& dict) {
-      destroy();
-      merge(dict);
-    }
-
-    inline String operator [] (const String& keystr) { return search(keystr); }
-    inline String operator [] (size_t i) { return value(i); }
-    inline int8_t operator () (const String& keystr, const String& valstr) { return insert(keystr, valstr); }
-    inline int8_t operator () (const char* keystr, const char* valstr) { return insert(keystr, valstr); }
-
-    bool operator () (const String& keystr);
-
-    String operator () (size_t i) { return key(i); }
-    inline bool operator == (Dictionary& b);
-    inline bool operator != (Dictionary& b) { return (!(*this == b)); }
-    inline size_t count() { return ( Q ? Q->count() : 0); }
-
-#ifdef _LIBDEBUG_
-    void printNode(node* root);
-    void printDictionary(node* root);
-    void printDictionary() {
-      Serial.printf("\nDictionary::printDictionary:\n");
-      printDictionary(iRoot);
-      Serial.println();
-    };
-    void printArray() {
-      Q->printArray();
-    };
-#endif
-
-  private:
-// methods
-    int8_t              insert(uintNN_t key, const char* keystr, _DICT_KEY_TYPE keylen, const char* valstr, _DICT_VAL_TYPE vallen, node* leaf);
-    node*               search(uintNN_t key, node* leaf, const char* keystr, _DICT_KEY_TYPE keylen);
-
-    void                destroy_tree(node* leaf);
-    node*               deleteNode(node* root, uintNN_t key, const char* keystr, _DICT_KEY_TYPE keylen);
-    node*               minValueNode(node* n);
-
-    uintNN_t            crc(const void* data, size_t n_bytes);
-
-#ifdef _DICT_COMPRESS
-    int8_t              compressKey(const char* aStr);
-    int8_t              compressValue(const char* aStr);
-    void                decompressKey(const char* aBuf, _DICT_KEY_TYPE aLen);
-    void                decompressValue(const char* aBuf, _DICT_VAL_TYPE aLen);
-#endif
-
-// data
-    node*               iRoot;
-    NodeArray::NodeArray* Q;
-    size_t              initSize;
-
-    char*            iKeyTemp;
-    _DICT_KEY_TYPE      iKeyLen;
-    char*            iValTemp;
-    _DICT_VAL_TYPE      iValLen;
-};
-
-
 
 // ==== CONSTRUCTOR / DESTRUCTOR ==================================
 Dictionary::Dictionary(size_t init_size) {
@@ -284,7 +92,7 @@ Dictionary::Dictionary(size_t init_size) {
 
   // This is unlikely to fail as practically no memory is allocated by the NodeArray
   // All memory allocation is delegated to the first append
-  Q = new NodeArray::NodeArray(init_size);
+  Q = new NodeArray(init_size);
   initSize = init_size;
 
 #ifdef _DICT_COMPRESS
@@ -311,10 +119,6 @@ Dictionary::~Dictionary() {
 // ==== PUBLIC METHODS ===============================================
 
 // ===== INSERTS =====================================================
-int8_t Dictionary::insert(const String& keystr, const String& valstr) {
-  return insert(keystr.c_str(), valstr.c_str());
-}
-
 int8_t Dictionary::insert(const char* keystr, const char* valstr) {
   // TODO: decide if to check for length here
   iKeyLen = strnlen(keystr, _DICT_KEYLEN + 1);
@@ -363,10 +167,6 @@ int8_t Dictionary::insert(const char* keystr, const char* valstr) {
 
 
 // ==== SEARCHES AND LOOKUPS ===============================================
-String Dictionary::search(const String& keystr) {
-    return search(keystr.c_str());
-}
-
 String Dictionary::search(const char* keystr) {
     iKeyLen = strnlen(keystr, _DICT_KEYLEN + 1);
 #ifdef _DICT_COMPRESS
@@ -438,7 +238,7 @@ void Dictionary::destroy() {
     destroy_tree(iRoot);
     iRoot = NULL;
     delete Q;
-    Q = new NodeArray::NodeArray(initSize);
+    Q = new NodeArray(initSize);
 }
 
 int8_t Dictionary::remove(const String& keystr) {

--- a/src/Dictionary.h
+++ b/src/Dictionary.h
@@ -195,16 +195,16 @@ class Dictionary {
     Dictionary(size_t init_size = 10);
     ~Dictionary();
 
-    inline int8_t       insert(String keystr, String valstr);
+    inline int8_t       insert(const String& keystr, const String& valstr);
     int8_t              insert(const char* keystr, const char* valstr);
     
-    inline String       search(String keystr);
+    inline String       search(const String& keystr);
     String              search(const char* keystr);
     String              key(size_t i);
     String              value(size_t i);
 
     void                destroy();
-    inline int8_t       remove(String keystr);
+    inline int8_t       remove(const String& keystr);
     int8_t              remove(const char* keystr);
 
     size_t              size();
@@ -212,7 +212,8 @@ class Dictionary {
     size_t              esize();
     
     String              json();
-    int8_t              jload (String json, int num = 0);
+    inline int8_t       jload (const String& json, int num = 0);
+    int8_t              jload (const char* json, int num = 0);
     int8_t              merge (Dictionary& dict);
 
 
@@ -221,12 +222,12 @@ class Dictionary {
       merge(dict);
     }
 
-    inline String operator [] (String keystr) { return search(keystr); }
+    inline String operator [] (const String& keystr) { return search(keystr); }
     inline String operator [] (size_t i) { return value(i); }
-    inline int8_t operator () (String keystr, String valstr) { return insert(keystr, valstr); }
+    inline int8_t operator () (const String& keystr, const String& valstr) { return insert(keystr, valstr); }
     inline int8_t operator () (const char* keystr, const char* valstr) { return insert(keystr, valstr); }
 
-    bool operator () (String keystr);
+    bool operator () (const String& keystr);
 
     String operator () (size_t i) { return key(i); }
     inline bool operator == (Dictionary& b);
@@ -310,7 +311,7 @@ Dictionary::~Dictionary() {
 // ==== PUBLIC METHODS ===============================================
 
 // ===== INSERTS =====================================================
-int8_t Dictionary::insert(String keystr, String valstr) {
+int8_t Dictionary::insert(const String& keystr, const String& valstr) {
   return insert(keystr.c_str(), valstr.c_str());
 }
 
@@ -362,7 +363,7 @@ int8_t Dictionary::insert(const char* keystr, const char* valstr) {
 
 
 // ==== SEARCHES AND LOOKUPS ===============================================
-String Dictionary::search(String keystr) {
+String Dictionary::search(const String& keystr) {
     return search(keystr.c_str());
 }
 
@@ -440,7 +441,7 @@ void Dictionary::destroy() {
     Q = new NodeArray::NodeArray(initSize);
 }
 
-int8_t Dictionary::remove(String keystr) {
+int8_t Dictionary::remove(const String& keystr) {
     return remove(keystr.c_str());
 }
 
@@ -517,10 +518,10 @@ size_t Dictionary::esize() {
 
 // ==== JSON RELATED ================================================
 String Dictionary::json() {
-    String s;
+    String s((char *)0);    // do not pre-allocate anything, reserve() will follow
 
     s.reserve(jsize());
-    s = '{';
+    s += '{';
 
     size_t ct = count();
     for (size_t i = 0; i < ct; i++) {
@@ -532,13 +533,16 @@ String Dictionary::json() {
     return s;
 }
 
+int8_t Dictionary::jload(const String& json, int num) {
+    return jload(json.c_str(), num);
+}
 
-int8_t Dictionary::jload(String json, int num) {
+int8_t Dictionary::jload(const char* c, int num) {
     bool insideQoute = false;
     bool nextVerbatim = false;
     bool isValue = false;
-    const char* c = json.c_str();
-    size_t len = json.length();
+    //const char* c = json.c_str();
+    size_t len = strlen(c);
     int p = 0;
     String currentKey;
     String currentValue;
@@ -616,7 +620,7 @@ int8_t Dictionary::merge(Dictionary& dict) {
 
 // ==== OPERATORS ====================================
 
-bool Dictionary::operator () (String keystr) {
+bool Dictionary::operator () (const String& keystr) {
     iKeyLen = keystr.length();
     if (iKeyLen > _DICT_KEYLEN) return false;
 

--- a/src/DictionaryDeclarations.h
+++ b/src/DictionaryDeclarations.h
@@ -1,0 +1,217 @@
+/*
+  Implementation of the Dictionary data type
+  for String key-value pairs, based on
+  CRC32/64 has keys and binary tree search
+
+  ---
+
+  Copyright (C) Anatoli Arkhipenko, 2020
+  All rights reserved.
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifndef _DICT_KEYLEN
+#define _DICT_KEYLEN 64
+#endif
+
+#if _DICT_KEYLEN < UINT8_MAX
+#define _DICT_KEY_TYPE  uint8_t
+#endif
+
+#if _DICT_KEYLEN >= UINT8_MAX && _DICT_KEYLEN < UINT16_MAX
+#define _DICT_KEY_TYPE  uint16_t
+#endif
+
+#if _DICT_KEYLEN >= UINT16_MAX && _DICT_KEYLEN < UINT32_MAX
+#define _DICT_KEY_TYPE  uint32_t
+#endif
+
+// What is the likelihood of a microcontroller having that much memory?
+#if _DICT_KEYLEN >= UINT32_MAX
+#define _DICT_KEY_TYPE  uint64_t
+#endif
+
+
+
+#ifndef _DICT_VALLEN
+#define _DICT_VALLEN 254
+#endif
+
+#if _DICT_VALLEN < UINT8_MAX
+#define _DICT_VAL_TYPE  uint8_t
+#endif
+
+#if _DICT_VALLEN >= UINT8_MAX && _DICT_VALLEN < UINT16_MAX
+#define _DICT_VAL_TYPE  uint16_t
+#endif
+
+#if _DICT_VALLEN >= UINT16_MAX && _DICT_VALLEN < UINT32_MAX
+#define _DICT_VAL_TYPE  uint32_t
+#endif
+
+#if _DICT_VALLEN >= UINT32_MAX
+#define _DICT_VAL_TYPE  uint64_t
+#endif
+
+
+
+#define DICTIONARY_OK         0
+#define DICTIONARY_ERR      (-1)
+#define DICTIONARY_MEM      (-2)
+#define DICTIONARY_OOB      (-3)
+
+#define DICTIONARY_COMMA    (-20)
+#define DICTIONARY_COLON    (-21)
+#define DICTIONARY_QUOTE    (-22)
+#define DICTIONARY_BCKSL    (-23)
+#define DICTIONARY_EOF      (-99)
+
+
+// There is no CRC calculation anymore, but the naming stuck
+#ifndef _DICT_CRC
+#define _DICT_CRC  32
+#endif
+
+#if !( _DICT_CRC == 16 || _DICT_CRC == 32 || _DICT_CRC == 64)
+#define _DICT_CRC  32
+#endif
+
+#if _DICT_CRC == 16
+#define uintNN_t uint16_t
+#endif
+
+#if _DICT_CRC == 32
+#define uintNN_t uint32_t
+#endif
+
+#if _DICT_CRC == 64
+#define uintNN_t uint64_t
+#endif
+
+#if defined(_DICT_COMPRESS_SHOCO)
+
+#define _DICT_COMPRESS
+#define _DICT_EXTRA 0
+#include "shoco/shoco.h"
+
+#elif defined (_DICT_COMPRESS_SMAZ)
+
+#define _DICT_COMPRESS
+#define _DICT_EXTRA 0
+extern "C" {
+#include "smaz/smaz.h"
+}
+#endif
+
+#ifndef _DICT_EXTRA
+#define _DICT_EXTRA 1
+#endif
+
+
+#include <Arduino.h>
+#include "NodeArrayDecl.h"
+//using namespace NodeArray;
+
+#ifdef _DICT_PACK_STRUCTURES
+class __attribute((__packed__)) Dictionary {
+#else
+class Dictionary {
+#endif
+  public:
+    Dictionary(size_t init_size = 10);
+    ~Dictionary();
+
+    inline int8_t       insert(const String& keystr, const String& valstr){return insert(keystr.c_str(), valstr.c_str());};
+    int8_t              insert(const char* keystr, const char* valstr);
+    
+    inline String       search(const String& keystr){return search(keystr.c_str());};
+    String              search(const char* keystr);
+    String              key(size_t i);
+    String              value(size_t i);
+
+    void                destroy();
+    inline int8_t       remove(const String& keystr);
+    int8_t              remove(const char* keystr);
+
+    size_t              size();
+    size_t              jsize();
+    size_t              esize();
+    
+    String              json();
+    inline int8_t       jload (const String& json, int num = 0);
+    int8_t              jload (const char* json, int num = 0);
+    int8_t              merge (Dictionary& dict);
+
+
+    void operator = (Dictionary& dict) {
+      destroy();
+      merge(dict);
+    }
+
+    inline String operator [] (const String& keystr) { return search(keystr); }
+    inline String operator [] (size_t i) { return value(i); }
+    inline int8_t operator () (const String& keystr, const String& valstr) { return insert(keystr, valstr); }
+    inline int8_t operator () (const char* keystr, const char* valstr) { return insert(keystr, valstr); }
+
+    bool operator () (const String& keystr);
+
+    String operator () (size_t i) { return key(i); }
+    bool operator == (Dictionary& b);
+    inline bool operator != (Dictionary& b) { return (!(*this == b)); }
+    inline size_t count() { return ( Q ? Q->count() : 0); }
+
+#ifdef _LIBDEBUG_
+    void printNode(node* root);
+    void printDictionary(node* root);
+    void printDictionary() {
+      Serial.printf("\nDictionary::printDictionary:\n");
+      printDictionary(iRoot);
+      Serial.println();
+    };
+    void printArray() {
+      Q->printArray();
+    };
+#endif
+
+  private:
+// methods
+    int8_t              insert(uintNN_t key, const char* keystr, _DICT_KEY_TYPE keylen, const char* valstr, _DICT_VAL_TYPE vallen, node* leaf);
+    node*               search(uintNN_t key, node* leaf, const char* keystr, _DICT_KEY_TYPE keylen);
+
+    void                destroy_tree(node* leaf);
+    node*               deleteNode(node* root, uintNN_t key, const char* keystr, _DICT_KEY_TYPE keylen);
+    node*               minValueNode(node* n);
+
+    uintNN_t            crc(const void* data, size_t n_bytes);
+
+#ifdef _DICT_COMPRESS
+    int8_t              compressKey(const char* aStr);
+    int8_t              compressValue(const char* aStr);
+    void                decompressKey(const char* aBuf, _DICT_KEY_TYPE aLen);
+    void                decompressValue(const char* aBuf, _DICT_VAL_TYPE aLen);
+#endif
+
+// data
+    node*               iRoot;
+    NodeArray*          Q;
+    size_t              initSize;
+
+    char*            iKeyTemp;
+    _DICT_KEY_TYPE      iKeyLen;
+    char*            iValTemp;
+    _DICT_VAL_TYPE      iValLen;
+};

--- a/src/NodeArray.h
+++ b/src/NodeArray.h
@@ -27,75 +27,7 @@
 #ifndef _NODEARRAY_H
 #define _NODEARRAY_H
 
-namespace NodeArray {
-
-#define NODEARRAY_OK    0
-#define NODEARRAY_ERR   (-1)
-#define NODEARRAY_MEM   (-2)
-
-#ifdef _DICT_PACK_STRUCTURES
-class __attribute((__packed__)) node {
-#else
-class node {
-#endif
-  public:
-
-    void* operator new(size_t size) {
-
-        void* p = NULL;
-#if defined (ARDUINO_ARCH_ESP32) && defined(_DICT_USE_PSRAM)
-      if (psramFound()) {
-        p = ps_malloc(size);
-      }
-#endif
-      if (!p) p = malloc(size);
-#ifdef _LIBDEBUG_
-      Serial.printf("NODE-NEW: size=%d (%d) k/v sizes=%d, %d, ptr=%u\n", size, sizeof(node), sizeof(_DICT_KEY_TYPE), sizeof(_DICT_VAL_TYPE), (uint32_t)p);
-#endif    
-    return p;
-    }
-
-    void operator delete(void* p) {
-      if ( p == NULL ) return;
-      node* n = (node*)p;
-
-      // Delete key/value strings
-      if ( n->keybuf ) { 
-        free(n->keybuf);
-        n->keybuf = NULL;
-      }
-      if ( n->valbuf ) {
-          free(n->valbuf);
-          n->valbuf = NULL;
-      }
-      free(p);
-#ifdef _LIBDEBUG_
-      Serial.printf("NODE-DELETE: Freed memory block %u\n", (uint32_t)p);
-#endif    
-    }
-
-    uintNN_t    key() {
-        uintNN_t k = 0;
-        
-        memcpy((void*)&k, keybuf, ksize < sizeof(uintNN_t) ? ksize : sizeof(uintNN_t));
-        return k;
-    }
-    
-    int8_t      create(const char* aKey, _DICT_KEY_TYPE aKeySize, const char* aVal, _DICT_VAL_TYPE aValSize, node* aLeft, node* aRight);
-    int8_t      updateValue(const char* aVal, _DICT_VAL_TYPE aValSize);
-    int8_t      updateKey(const char* aKey, _DICT_KEY_TYPE aKeySize);
-
-#ifdef _LIBDEBUG_
-    void printNode();
-#endif
-    char*           keybuf;
-    _DICT_KEY_TYPE  ksize;
-    char*           valbuf;
-    _DICT_VAL_TYPE  vsize;
-    node*           left;
-    node*           right;
-};
-
+#include "NodeArrayDecl.h"
 
 int8_t node::create(const char* aKey, _DICT_KEY_TYPE aKeySize, const char* aVal, _DICT_VAL_TYPE aValSize, node* aLeft, node* aRight) {
 
@@ -261,62 +193,7 @@ void node::printNode() {
 }
 #endif
 
-#ifdef _DICT_PACK_STRUCTURES
-class __attribute((__packed__)) NodeArray {
-#else
-class NodeArray {
-#endif   
-  public:
-    // init the queue (constructor).
-    NodeArray(size_t init_size = 10);
 
-    // clear the queue (destructor).
-    ~NodeArray();
-
-    // add an item to the queue.
-    int8_t append(const node* i);
-
-    // remove an item from the queue.
-    void remove(const node* i);
-
-    // check if the queue is empty.
-    bool isEmpty() const;
-
-    //    // get the number of items in the queue.
-    size_t count() const;
-
-    // check if the queue is full.
-    bool isFull() const;
-
-
-    node* operator [] (const size_t i) {
-      if (i >= items) {
-        //        exit ("QUEUE: Out of bounds");
-        return NULL;
-      }
-      return contents[i];
-    }
-
-#ifdef _LIBDEBUG_
-    void printArray();
-#endif
-
-  private:
-    // resize the size of the queue.
-    int8_t resize(const size_t s);
-
-    // exit report method in case of error.
-    //    void exit (const char * m) const;
-
-    // the initial size of the queue.
-    size_t initialSize;
-
-    node** contents;    // the array of the queue.
-
-    size_t size;        // the size of the queue.
-    size_t items;       // the number of items of the queue.
-    size_t tail;        // the tail of the queue.
-};
 
 // init the queue (constructor).
 NodeArray::NodeArray(size_t init_size) {
@@ -471,6 +348,5 @@ bool NodeArray::isFull() const {
 size_t NodeArray::count() const {
   return items;
 }
-} // namespace NodeArray
-#endif // _NODEARRAY_H
 
+#endif // _NODEARRAY_H

--- a/src/NodeArrayDecl.h
+++ b/src/NodeArrayDecl.h
@@ -1,0 +1,129 @@
+#pragma once
+#include "DictionaryDeclarations.h"
+
+#define NODEARRAY_OK    0
+#define NODEARRAY_ERR   (-1)
+#define NODEARRAY_MEM   (-2)
+
+#ifdef _DICT_PACK_STRUCTURES
+class __attribute((__packed__)) node
+#else
+class node
+#endif
+{
+  public:
+
+    void* operator new(size_t size) {
+
+        void* p = NULL;
+#if defined (ARDUINO_ARCH_ESP32) && defined(_DICT_USE_PSRAM)
+      if (psramFound()) {
+        p = ps_malloc(size);
+      }
+#endif
+      if (!p) p = malloc(size);
+#ifdef _LIBDEBUG_
+      Serial.printf("NODE-NEW: size=%d (%d) k/v sizes=%d, %d, ptr=%u\n", size, sizeof(node), sizeof(_DICT_KEY_TYPE), sizeof(_DICT_VAL_TYPE), (uint32_t)p);
+#endif    
+    return p;
+    }
+
+    void operator delete(void* p) {
+      if ( p == NULL ) return;
+      node* n = (node*)p;
+
+      // Delete key/value strings
+      if ( n->keybuf ) { 
+        free(n->keybuf);
+        n->keybuf = NULL;
+      }
+      if ( n->valbuf ) {
+          free(n->valbuf);
+          n->valbuf = NULL;
+      }
+      free(p);
+#ifdef _LIBDEBUG_
+      Serial.printf("NODE-DELETE: Freed memory block %u\n", (uint32_t)p);
+#endif    
+    }
+
+    uintNN_t    key() {
+        uintNN_t k = 0;
+        
+        memcpy((void*)&k, keybuf, ksize < sizeof(uintNN_t) ? ksize : sizeof(uintNN_t));
+        return k;
+    }
+    
+    int8_t      create(const char* aKey, _DICT_KEY_TYPE aKeySize, const char* aVal, _DICT_VAL_TYPE aValSize, node* aLeft, node* aRight);
+    int8_t      updateValue(const char* aVal, _DICT_VAL_TYPE aValSize);
+    int8_t      updateKey(const char* aKey, _DICT_KEY_TYPE aKeySize);
+
+#ifdef _LIBDEBUG_
+    void printNode();
+#endif
+    char*           keybuf;
+    _DICT_KEY_TYPE  ksize;
+    char*           valbuf;
+    _DICT_VAL_TYPE  vsize;
+    node*           left;
+    node*           right;
+};
+
+
+#ifdef _DICT_PACK_STRUCTURES
+class __attribute((__packed__)) NodeArray
+#else
+class NodeArray
+#endif   
+{
+  public:
+    // init the queue (constructor).
+    NodeArray(size_t init_size = 10);
+
+    // clear the queue (destructor).
+    ~NodeArray();
+
+    // add an item to the queue.
+    int8_t append(const node* i);
+
+    // remove an item from the queue.
+    void remove(const node* i);
+
+    // check if the queue is empty.
+    bool isEmpty() const;
+
+    //    // get the number of items in the queue.
+    size_t count() const;
+
+    // check if the queue is full.
+    bool isFull() const;
+
+
+    node* operator [] (const size_t i) {
+      if (i >= items) {
+        //        exit ("QUEUE: Out of bounds");
+        return NULL;
+      }
+      return contents[i];
+    }
+
+#ifdef _LIBDEBUG_
+    void printArray();
+#endif
+
+  private:
+    // resize the size of the queue.
+    int8_t resize(const size_t s);
+
+    // exit report method in case of error.
+    //    void exit (const char * m) const;
+
+    // the initial size of the queue.
+    size_t initialSize;
+
+    node** contents;    // the array of the queue.
+
+    size_t size;        // the size of the queue.
+    size_t items;       // the number of items of the queue.
+    size_t tail;        // the tail of the queue.
+};


### PR DESCRIPTION
It's just a Proof of concept, not a real PR (yet).

With my recent changes in #5 I've faced some strange issues when populating dictionary if it was dynamically created like this: Dictionary *dict = new Dictionary(N);
Controller just crashed after adding only root entry
 
```

DICT-insert: Inserting key: hostname
NODE-NEW: size=40 (40) k/v sizes=8, 8, ptr=1073679068
NODE-CREATE: created a node:
node:
	keyNN   = 1953722216
	key  = 686f73746e616d65 (8) (0)
	val  = 656d627569747374 (8) (0)
	Left n  = 0
	Right n = 0
DICT-insert: creating root entry. rc = 0
NODEARRAY-APPEND: successfully added a node 3fff0adc. Cur size: 1
DICT-insert: Inserting key: APonly
DICT-insert: Create left. key = 1852788801
NODE-NEW: size=40 (40) k/v sizes=8, 8, ptr=1073677500
NODE-CREATE: created a node:
node:
	keyNN   = 1852788801
	key  = 41506f6e6c79 (6) (0)
	val  = 66616c7365 (5) (0)
	Left n  = 0
	Right n = 0

--------------- CUT HERE FOR EXCEPTION DECODER ---------------

Exception (29):
epc1=0x4020a5c4 epc2=0x00000000 epc3=0x00000000 excvaddr=0x00000004 depc=0x00000000

```

Was trying to trace it down in NodeArray lib but than gave up. Actually what I need from dictionary could be implemented with std::map but I wanted to have some wrapper methods, like json import/export, etc...
So, I just removed NodeArray and replaceddict  backend with plain std::map. It is much more simple and easy to iterate and access while keeping API compatible (almost).

I'm a little bit confused with dict key length though... Why is it still there if there is no any hash/crc and keys are saved as the same char literals?
Anyway, @arkhipenko pls take a look at my changes, is it worth the efforts?
It works for me as simple key:val now, though not tested with full features like compression.
Maybe you have some unit tests to try it?