### PR TITLE
Fix indentation and a missing semicolon in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ This is a valid JSON load as well:
 ```
 {
     "value" : 3,
-	anothervalue : "23",
-	and_this : is_ok_too,
+    anothervalue : "23",
+    and_this : is_ok_too,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can control the maximum allowable length of both keys and values vis the fol
 ```c++
 d("ssid", "devices");
 d("pwd", "********");
-d("url", "http://ota.home.lan")
+d("url", "http://ota.home.lan");
 d("port", "80");
 d("plumless", "plumless");
 d("buckeroo", "buckeroo");  // OR:


### PR DESCRIPTION
There was a missing semicolon on line 61. Also fixed some indentation mistakes. This makes the text just look nicer.